### PR TITLE
fix: Fix path to cypress files in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,7 +41,7 @@
             "@/public/*": ["./public/*"]
         }
     },
-    "exclude": ["node_modules", "./out/**/*", "src/cypress/**/*.ts"],
+    "exclude": ["node_modules", "./out/**/*", "cypress/**/*.ts"],
     "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]
 }
 


### PR DESCRIPTION
Cypress spec files should use their own tsconfig extension, to avoid the isolatedModules flag